### PR TITLE
seed함수에 config 인자 추가 및 inference시에 저장되는 csv의 이름을 자동으로 관리

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -57,7 +57,7 @@ def num_to_label(label):
   return origin_label
 
 def main(config: Dict):
-    set_seed()
+    set_seed(config)
     """
         주어진 dataset csv 파일과 같은 형태일 경우 inference 가능한 코드입니다.
     """
@@ -85,14 +85,14 @@ def main(config: Dict):
     # 아래 directory와 columns의 형태는 지켜주시기 바랍니다.
     output = pd.DataFrame({'id':pd.Series(range(len(pred_answer))),'pred_label':pred_answer,'probs':output_prob,})
 
-    output.to_csv('./prediction/submission.csv', index=False) # 최종적으로 완성된 예측한 라벨 csv 파일 형태로 저장.
+    output.to_csv('./prediction/'+'_'.join(config['arch']['model_name'].split('/') + config['arch']['model_detail'].split())+'_submission.csv', index=False) # 최종적으로 완성된 예측한 라벨 csv 파일 형태로 저장.
     #### 필수!! ##############################################
     print('---- Finish! ----')
 
 
 if __name__ == '__main__':
 
-    selected_config = 'base_config.json'
+    selected_config = 'roberta-base.json'
 
     with open(f'./configs/{selected_config}', 'r') as f:
         config = json.load(f)

--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ from models import base_model
 
 MODEL = base_model
 
-def set_seed():
+def set_seed(config: Dict):
     seed = config['seed']
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
@@ -39,7 +39,7 @@ def set_seed():
 
 def main(config: Dict):
     #seed 고정
-    set_seed()
+    set_seed(config)
 
     # 하이퍼 파라미터 등 각종 설정값을 입력받습니다
     # 터미널 실행 예시 : python3 run.py --batch_size=64 ...
@@ -100,7 +100,7 @@ def main(config: Dict):
 
 if __name__ == '__main__':
 
-    selected_config = 'base_config.json'
+    selected_config = 'roberta-base.json'
 
     with open(f'./configs/{selected_config}', 'r') as f:
         config = json.load(f)


### PR DESCRIPTION
- inference 시에 seed함수 내의 config를 인식하려면 인자로 전달해줘야 해서 추가했습니다.
- inference 시에 최종적으로 저장되는 submission의 파일 이름이 model_name과 model_detail을 '_' 를 기준으로 추가되도록 구성했습니다. ex) klue_roberta-base_v_submission